### PR TITLE
Add some basic database indexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ COMMANDS := web cli
 # Build all commands
 build: $(COMMANDS)
 
+# Test all directories
+test:
+	@echo "Testing..."
+	@go test ./...
+
 # Build a specific command
 $(COMMANDS):
 	@echo "Building $@..."

--- a/internal/database/common.go
+++ b/internal/database/common.go
@@ -1,4 +1,4 @@
-package models
+package database
 
 const (
 	// WebhookCollectionName is the name of the collection for the webhook data

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -29,6 +30,29 @@ func InitDB(dataSourceName string, dbName string) {
 	}
 
 	DB = client.Database(dbName)
+
+	setupIndexes()
+}
+
+// setupIndexes sets up the indexes for the database
+func setupIndexes() {
+	// Setup index on created_at
+	indexModel := mongo.IndexModel{
+		Keys: bson.D{{Key: "created_at", Value: -1}},
+	}
+	_, err := DB.Collection(WebhookCollectionName).Indexes().CreateOne(Ctx, indexModel)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	// Setup index on serviceName
+	indexModel = mongo.IndexModel{
+		Keys: bson.D{{Key: "serviceName", Value: 1}},
+	}
+	_, err = DB.Collection(WebhookCollectionName).Indexes().CreateOne(Ctx, indexModel)
+	if err != nil {
+		logrus.Fatal(err)
+	}
 }
 
 // CloseDB closes the database connection

--- a/internal/web/api/controllers/firehose/firehose.go
+++ b/internal/web/api/controllers/firehose/firehose.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"plex_monitor/internal/database"
-	"plex_monitor/internal/database/models"
 
 	"github.com/go-chi/render"
 	"go.mongodb.org/mongo-driver/bson"
@@ -14,7 +13,7 @@ import (
 // Firehose is the endpoint that streams data to the client
 func Firehose(w http.ResponseWriter, r *http.Request) {
 	opts := options.Find().SetLimit(1000).SetSort(bson.D{{Key: "created_at", Value: -1}})
-	cursor, err := database.DB.Collection(models.WebhookCollectionName).Find(context.Background(), bson.D{}, opts)
+	cursor, err := database.DB.Collection(database.WebhookCollectionName).Find(context.Background(), bson.D{}, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/web/api/controllers/webhook/ombi.go
+++ b/internal/web/api/controllers/webhook/ombi.go
@@ -26,7 +26,7 @@ func (rms OmbiMonitoringService) fire(l *logrus.Entry, w http.ResponseWriter, r 
 		return fmt.Errorf("unable to parse request (bad request data): %s", err)
 	}
 
-	_, err = database.DB.Collection(models.WebhookCollectionName).InsertOne(database.Ctx, ombiWebhookData)
+	_, err = database.DB.Collection(database.WebhookCollectionName).InsertOne(database.Ctx, ombiWebhookData)
 	if err != nil {
 		return fmt.Errorf("unable to write to database: %s", err)
 	}

--- a/internal/web/api/controllers/webhook/plex.go
+++ b/internal/web/api/controllers/webhook/plex.go
@@ -32,7 +32,7 @@ func (pms PlexMonitoringService) fire(l *logrus.Entry, w http.ResponseWriter, r 
 		return fmt.Errorf("unable to parse request (bad request data): %s", err)
 	}
 
-	_, err = database.DB.Collection(models.WebhookCollectionName).InsertOne(database.Ctx, plexWebhookRequest)
+	_, err = database.DB.Collection(database.WebhookCollectionName).InsertOne(database.Ctx, plexWebhookRequest)
 	if err != nil {
 		return fmt.Errorf("unable to write to database: %s", err)
 	}

--- a/internal/web/api/controllers/webhook/radarr.go
+++ b/internal/web/api/controllers/webhook/radarr.go
@@ -54,7 +54,7 @@ func (rms RadarrMonitoringService) fire(l *logrus.Entry, w http.ResponseWriter, 
 		healthData.ServiceName = "radarr"
 
 		// Store the data in the database
-		_, err := database.DB.Collection(models.WebhookCollectionName).InsertOne(database.Ctx, healthData)
+		_, err := database.DB.Collection(database.WebhookCollectionName).InsertOne(database.Ctx, healthData)
 		if err != nil {
 			return fmt.Errorf("could not store data: %w", err)
 		}
@@ -63,7 +63,7 @@ func (rms RadarrMonitoringService) fire(l *logrus.Entry, w http.ResponseWriter, 
 		return nil
 	}
 
-	_, err = database.DB.Collection(models.WebhookCollectionName).InsertOne(database.Ctx, radarrWebhookData)
+	_, err = database.DB.Collection(database.WebhookCollectionName).InsertOne(database.Ctx, radarrWebhookData)
 	if err != nil {
 		return fmt.Errorf("could not store data: %w", err)
 	}

--- a/internal/web/api/controllers/webhook/sonarr.go
+++ b/internal/web/api/controllers/webhook/sonarr.go
@@ -55,7 +55,7 @@ func (rms SonarrMonitoringService) fire(l *logrus.Entry, w http.ResponseWriter, 
 		healthData.ServiceName = "sonarr"
 
 		// Store the data in the database
-		_, err := database.DB.Collection(models.WebhookCollectionName).InsertOne(database.Ctx, healthData)
+		_, err := database.DB.Collection(database.WebhookCollectionName).InsertOne(database.Ctx, healthData)
 		if err != nil {
 			return fmt.Errorf("could not store data: %w", err)
 		}
@@ -64,7 +64,7 @@ func (rms SonarrMonitoringService) fire(l *logrus.Entry, w http.ResponseWriter, 
 		return nil
 	}
 
-	_, err = database.DB.Collection(models.WebhookCollectionName).InsertOne(database.Ctx, sonarrWebhookData)
+	_, err = database.DB.Collection(database.WebhookCollectionName).InsertOne(database.Ctx, sonarrWebhookData)
 	if err != nil {
 		return fmt.Errorf("unable to write to database: %s", err)
 	}

--- a/internal/web/api/controllers/webhook/webhook_test.go
+++ b/internal/web/api/controllers/webhook/webhook_test.go
@@ -113,7 +113,7 @@ func TestWebhookWithPlexService(t *testing.T) {
 	}
 
 	// Assert that we stored the event in the database
-	evt, err := database.DB.Collection(models.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"event": "media.pause"})
+	evt, err := database.DB.Collection(database.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"event": "media.pause"})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), evt)
 
@@ -159,7 +159,7 @@ func TestWebhookWithSonarrService(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Assert that we stored the event in the database
-	count, err := database.DB.Collection(models.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"series.id": 73})
+	count, err := database.DB.Collection(database.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"series.id": 73})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 
@@ -205,7 +205,7 @@ func TestWebhookWithSonarrServiceHealth(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Assert that we stored the event in the database
-	count, err := database.DB.Collection(models.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"message": "Indexers unavailable due to failures: indexerName"})
+	count, err := database.DB.Collection(database.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"message": "Indexers unavailable due to failures: indexerName"})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 
@@ -251,7 +251,7 @@ func TestWebhookWithRadarrService(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Assert that we stored the event in the database
-	count, err := database.DB.Collection(models.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"movie.id": 686})
+	count, err := database.DB.Collection(database.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"movie.id": 686})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 
@@ -297,7 +297,7 @@ func TestWebhookWithRadarrServiceHealth(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Assert that we stored the event in the database
-	count, err := database.DB.Collection(models.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"message": "Indexers unavailable due to failures: indexerName"})
+	count, err := database.DB.Collection(database.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"message": "Indexers unavailable due to failures: indexerName"})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 
@@ -343,7 +343,7 @@ func TestWebhookWithOmbiService(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Assert that we stored the event in the database
-	count, err := database.DB.Collection(models.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"requestId": "1234"})
+	count, err := database.DB.Collection(database.WebhookCollectionName).CountDocuments(database.Ctx, bson.M{"requestId": "1234"})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 


### PR DESCRIPTION
Adds indexes to `created_at` and `serviceName` in the webhooks collection. (these are used for the firehose and will be used for other queries heavily)